### PR TITLE
whitelist index.js when publishing NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "`[].map(f)` for older browsers",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
     "tape": "~2.3.2"
   },


### PR DESCRIPTION
I noticed that this module includes the `test`, `example` folders as well as `.travis.yml` in the published NPM module.

![image](https://user-images.githubusercontent.com/13087421/58372023-0766dd00-7f4a-11e9-80ce-6cca4dc6ed92.png)

In the spirit of keeping module sizes small, this PR whitelists `index.js`. :)